### PR TITLE
Decadimento ristretto sostituito con Obsolescenza Limitata

### DIFF
--- a/articles/cosmos-db/consistency-levels.md
+++ b/articles/cosmos-db/consistency-levels.md
@@ -25,14 +25,14 @@ ms.lasthandoff: 06/17/2017
 
 ---
 # <a name="tunable-data-consistency-levels-in-azure-cosmos-db"></a>Livelli di coerenza dei dati ottimizzabili in Azure Cosmos DB
-Azure Cosmos DB è stato progettato da zero pensando alla distribuzione globale di tutti i modelli di dati. È pensato per offrire garanzie di bassa latenza stimabile, Contratto di servizio con disponibilità al 99,99% e più modelli di coerenza ben definiti meno severi. Azure Cosmos DB offre attualmente cinque livelli di coerenza: assoluta, decadimento ristretto, sessione, prefisso coerente e finale. 
+Azure Cosmos DB è stato progettato da zero pensando alla distribuzione globale di tutti i modelli di dati. È pensato per offrire garanzie di bassa latenza stimabile, contratti di servizio con disponibilità al 99,99% e più modelli di coerenza ben definiti. Azure Cosmos DB offre attualmente cinque livelli di coerenza: assoluta, obsolescenza limitata, sessione, prefisso coerente e finale. 
 
-Oltre ai modelli di **coerenza assoluta** e **finale** offerti in genere dai database distribuiti, Azure Cosmos DB offre altri tre modelli di coerenza attentamente codificati e operativi e ha convalidato la loro utilità in casi reali. Si tratta di livelli coerenza di **decadimento ristretto**, **sessione** e **prefisso coerente**. Questi cinque livelli di coerenza, collettivamente, consentono di bilanciare in modo informato coerenza, disponibilità e latenza. 
+Oltre ai modelli di **coerenza assoluta** e **finale** offerti in genere dai database distribuiti, Azure Cosmos DB offre altri tre modelli di coerenza attentamente codificati e operativi e ha convalidato la loro utilità in casi reali. Si tratta di livelli coerenza di **obsolescenza limitata**, **sessione** e **prefisso coerente**. Questi cinque livelli di coerenza, collettivamente, consentono di bilanciare in modo informato coerenza, disponibilità e latenza. 
 
 ## <a name="distributed-databases-and-consistency"></a>Coerenza e database distribuiti
-I database distribuiti a livello commerciale rientrano in due categorie: database che non offrono opzioni di coerenza comprovabili e ben definite e database che offrono due opzioni di programmabilità estreme (coerenza assoluta e coerenza finale). 
+I database distribuiti a livello commerciale rientrano in due categorie: database che non offrono opzioni di coerenza comprovabili e ben definite, e database che offrono due opzioni di programmabilità estreme (coerenza assoluta e coerenza finale). 
 
-Nel primo caso gli sviluppatori di applicazioni devono preoccuparsi della gestione di aspetti secondari come i protocolli di replica e si trovano a scendere a difficili compromessi tra coerenza, disponibilità, latenza e velocità effettiva. Il secondo tipo di database, invece, implica una pressione per la scelta di uno dei due estremi. Nonostante il grande numero di ricerche e proposte per oltre 50 modelli di coerenza, la community dei database distribuiti non è riuscita a commercializzare livelli di coerenza che vadano oltre la coerenza assoluta e quella finale. Cosmos DB consente agli sviluppatori di scegliere tra cinque modelli di coerenza ben definiti nell'ambito della coerenza: assoluta, decadimento ristretto, [sessione](http://dl.acm.org/citation.cfm?id=383631), prefisso coerente e finale. 
+Nel primo caso gli sviluppatori di applicazioni devono preoccuparsi della gestione di aspetti secondari, come i protocolli di replica, e si trovano a scendere a compromessi tra coerenza, disponibilità, latenza e velocità effettiva. Il secondo tipo di database, invece, implica una pressione per la scelta di uno dei due estremi. Nonostante il grande numero di ricerche e proposte per oltre 50 modelli di coerenza, la community dei database distribuiti non è riuscita a commercializzare livelli di coerenza che vadano oltre la coerenza assoluta e quella finale. Cosmos DB consente agli sviluppatori di scegliere tra cinque modelli di coerenza ben definiti: assoluta, obsolescenza limitata, [sessione](http://dl.acm.org/citation.cfm?id=383631), prefisso coerente e finale. 
 
 ![Azure Cosmos DB offre numerosi modelli di coerenza, ampi e ben definiti, tra cui scegliere](./media/consistency-levels/five-consistency-levels.png)
 
@@ -43,14 +43,14 @@ La tabella seguente illustra le garanzie specifiche fornite da ciascun livello d
 | Livello di coerenza | Garanzie |
 | --- | --- |
 | Assoluta | Linearità |
-| Obsolescenza associata | Prefisso coerente. Ritardo delle letture rispetto alle scritture in base a prefissi k o intervallo t |
+| Obsolescenza limitata | Prefisso coerente. Ritardo delle letture rispetto alle scritture in base a prefissi k o intervallo t |
 | sessione   | Prefisso coerente. Letture costanti, scritture costanti, lettura delle proprie scritture, scrittura basata sulle letture |
 | Prefisso coerente | Gli aggiornamenti restituiti sono un prefisso di tutti gli aggiornamenti, senza interruzioni |
 | Finale  | Letture non in ordine |
 
-È possibile configurare il livello di coerenza predefinito per l'account Cosmos DB (e successivamente ignorare l'impostazione del livello di coerenza per una specifica richiesta di lettura). Internamente, il livello di coerenza predefinito si applica ai dati all'interno dei set di partizioni che possono estendersi a più aree. Circa il 73% dei tenant di Microsoft usa il livello di coerenza sessione e il 20% il livello decadimento ristretto. È stato notato che circa il 3% dei clienti sperimenta i vari livelli di coerenza inizialmente prima di decidere quale sia il livello di coerenza specifico più adatto alla propria applicazione. È stato osservato anche che solo il 2% dei tenant eseguono l'override dei livelli di coerenza per ogni richiesta. 
+È possibile configurare il livello di coerenza predefinito per l'account Cosmos DB (e successivamente ignorare l'impostazione del livello di coerenza per una specifica richiesta di lettura). Internamente, il livello di coerenza predefinito si applica ai dati all'interno dei set di partizioni che possono estendersi a più aree. Circa il 73% dei tenant di Microsoft usa il livello di coerenza sessione e il 20% il livello obsolescenza limitata. È stato notato che circa il 3% dei clienti sperimenta i vari livelli di coerenza inizialmente prima di decidere quale sia il livello di coerenza specifico più adatto alla propria applicazione. È stato osservato anche che solo il 2% dei tenant eseguono l'override dei livelli di coerenza per ogni richiesta. 
 
-In Cosmos DB le operazioni di lettura servite con coerenza di sessione, prefisso coerente e finale sono due volte più economici delle operazioni di lettura con coerenza assoluta o decadimento ristretto. Il 99,99% dei contratti di servizi di Cosmos DB riguarda complessivamente aziende leader nel settore. Tali contratti includono garanzie di coerenza per quanto riguarda disponibilità, velocità effettiva e latenza. Viene eseguito un [controllo della linearità](http://dl.acm.org/citation.cfm?id=1806634), che usa continuamente i dati di telemetria del servizio e segnala esplicitamente eventuali violazioni della coerenza. Per il decadimento ristretto, vengono controllate e segnalate le eventuali violazioni dei limiti k e t. Per tutti i cinque livelli di coerenza flessibili, viene segnalata anche la [metrica probabilistica di decadimento ristretto](http://dl.acm.org/citation.cfm?id=2212359) direttamente all'utente.  
+In Cosmos DB le operazioni di lettura servite con coerenza di sessione, prefisso coerente e finale sono due volte meno dispendiose delle operazioni di lettura con coerenza assoluta o obsolescenza limitata. Il 99,99% dei contratti di servizi di Cosmos DB riguarda complessivamente aziende leader nel settore. Tali contratti includono garanzie di coerenza per quanto riguarda disponibilità, velocità effettiva e latenza. Viene eseguito un [controllo della linearità](http://dl.acm.org/citation.cfm?id=1806634), che usa continuamente i dati di telemetria del servizio e segnala esplicitamente eventuali violazioni della coerenza. Per obsolescenza limitata, vengono controllate e segnalate le eventuali violazioni dei limiti k e t. Per tutti i cinque livelli di coerenza flessibili, viene segnalata anche la [metrica probabilistica di obsolescenza limitata](http://dl.acm.org/citation.cfm?id=2212359) direttamente all'utente.  
 
 ## <a name="scope-of-consistency"></a>Ambito di coerenza
 L'ambito di granularità della coerenza è limitato alla richiesta del singolo utente. Una richiesta di scrittura può corrispondere a un'operazione di inserimento, sostituzione, upsert o eliminazione. Come per le operazioni di scrittura, anche per una transazione di lettura/query l'ambito equivale alla richiesta del singolo utente. Potrebbe essere chiesto all'utente di scorrere le pagine di un ampio set di risultati, che occupa varie partizioni, ma ciascuna transazione di lettura ha come ambito una singola pagina ed è servita dall'interno di una singola partizione.
@@ -63,24 +63,24 @@ L'ambito di granularità della coerenza è limitato alla richiesta del singolo u
 * la coerenza assoluta offre una garanzia di [linearità](https://aphyr.com/posts/313-strong-consistency-models) ovvero la garanzia che le letture restituiscano la versione più recente di un elemento. 
 * la coerenza assoluta garantisce che una scrittura sia visibile solo dopo che ne è stato eseguito il commit in modo permanente dal quorum di maggioranza delle repliche. Una scrittura può ottenere o il commit sincrono e permanente da parte della replica primaria e della maggioranza delle repliche secondarie o l'interruzione. Una lettura viene sempre confermata dalla quorum di maggioranza per le letture: un client non potrà mai vedere una scrittura parziale o di cui non sia stato eseguito il commit e leggerà sempre la più recente scrittura confermata. 
 * Gli account Azure Cosmos DB configurati per usare la coerenza assoluta non possono associare più di un'area di Azure con il loro account Azure Cosmos DB. 
-* Il costo di un'operazione di lettura (in termini di [unità richiesta](request-units.md) consumate) con il livello di coerenza assoluta è più alto rispetto ai livelli sessione e finale, ma uguale a quello del livello con obsolescenza associata.
+* Il costo di un'operazione di lettura (in termini di [unità richiesta](request-units.md) consumate) con il livello di coerenza assoluta è più alto rispetto ai livelli sessione e finale, ma uguale a quello del livello con obsolescenza limitata.
 
-**Obsolescenza associata**: 
+**Obsolescenza limitata**: 
 
-* La coerenza con decadimento ristretto garantisce che il ritardo delle letture sulle scritture sia al massimo pari a *K* versioni o prefissi di un elemento o all'intervallo di tempo *t*. 
-* Pertanto, quando si sceglie il decadimento ristretto, il "decadimento" può essere configurato in due modi: numero di versioni *K* dell'elemento del ritardo delle operazioni di lettura sulle operazioni di scrittura e l'intervallo di tempo *t* 
-* Il decadimento ristretto offre un ordine globale totale tranne all'interno della "finestra di decadimento". La garanzia di lettura monotona esiste in un'area sia all'interno che all'esterno della "finestra di decadimento". 
-* L'obsolescenza associata offre una maggiore garanzia di coerenza rispetto alla coerenza di sessione o finale. Per le applicazioni distribuite a livello globale, è consigliabile usare l'obsolescenza associata per gli scenari in cui si desidera una coerenza assoluta ma si desidera anche il 99,99% di disponibilità e bassa latenza. 
-* Gli account Azure Cosmos DB configurati con la coerenza con decadimento ristretto possono associare qualsiasi numero di aree di Azure con il proprio account Azure Cosmos DB. 
-* Il costo di un'operazione di lettura (in termini di unità richiesta consumate) con l'obsolescenza associata è più alto rispetto ai livelli sessione e finale, ma uguale a quello del livello assoluto.
+* La coerenza con obsolescenza limitata garantisce che il ritardo delle letture sulle scritture sia al massimo pari a *K* versioni o prefissi di un elemento o all'intervallo di tempo *t*. 
+* Pertanto, quando si sceglie il obsolescenza limitata, la "obsolescenza" può essere configurata in due modi: numero di versioni *K* dell'elemento del ritardo delle operazioni di lettura sulle operazioni di scrittura e l'intervallo di tempo *t* 
+* L'obsolescenza limitata offre un ordine globale totale tranne all'interno della "finestra di obsolescenza". La garanzia di lettura monotona esiste in un'area sia all'interno che all'esterno della "finestra di obsolescenza". 
+* L'obsolescenza limitata offre una maggiore garanzia di coerenza rispetto alla coerenza di sessione o finale. Per le applicazioni distribuite a livello globale, è consigliabile usare l'obsolescenza limitata per gli scenari in cui si desidera una coerenza assoluta ma si desidera anche il 99,99% di disponibilità e bassa latenza. 
+* Gli account Azure Cosmos DB configurati con la coerenza con obsolescenza limitata possono associare qualsiasi numero di aree di Azure con il proprio account Azure Cosmos DB. 
+* Il costo di un'operazione di lettura (in termini di unità richiesta consumate) con l'obsolescenza limitata è più alto rispetto ai livelli sessione e finale, ma uguale a quello del livello assoluto.
 
 **Sessione**: 
 
-* a differenza dei modelli di coerenza globale offerti dai livelli di coerenza assoluta e con obsolescenza associata, la coerenza di "sessione" ha come ambito una sessione del client. 
+* a differenza dei modelli di coerenza globale offerti dai livelli di coerenza assoluta e con obsolescenza limitata, la coerenza di "sessione" ha come ambito una sessione del client. 
 * La coerenza di sessione è ideale per tutti gli scenari in cui è coinvolto un dispositivo o una sessione utente poiché garantisce letture monotone, scritture monotone e garanzie di lettura di ciò che si scrive (RYW). 
 * La coerenza di sessione offre una coerenza prevedibile per una sessione e la massima velocità di scrittura, con latenza minima per scrittura e lettura. 
 * Gli account Azure Cosmos DB configurati con la coerenza sessione possono associare qualsiasi numero di aree di Azure con il proprio account Azure Cosmos DB. 
-* Il costo di un'operazione di lettura (in termini di unità richiesta consumate) con il livello di coerenza di sessione è minore rispetto ai livelli assoluto e con obsolescenza associata, ma maggiore rispetto al livello finale
+* Il costo di un'operazione di lettura (in termini di unità richiesta consumate) con il livello di coerenza di sessione è minore rispetto ai livelli assoluto e con obsolescenza limitata, ma maggiore rispetto al livello finale
 
 <a id="consistent-prefix"></a>
 **Prefisso coerente**: 
@@ -110,9 +110,9 @@ Per impostazione predefinita, per le risorse definite dall'utente, il livello di
 
 | Modalità di indicizzazione | Letture | Query |
 | --- | --- | --- |
-| Coerente (impostazione predefinita) |Selezionare tra assoluta, con decadimento ristretto, sessione, prefisso coerente o finale |Selezionare tra assoluta, con obsolescenza associata, sessione o finale |
-| Differita |Selezionare tra assoluta, con decadimento ristretto, sessione, prefisso coerente o finale |Finale |
-| Nessuno |Selezionare tra assoluta, con decadimento ristretto, sessione, prefisso coerente o finale |Non applicabile |
+| Coerente (impostazione predefinita) |Selezionare tra assoluta, con obsolescenza limitata, sessione, prefisso coerente o finale |Selezionare tra assoluta, con obsolescenza limitata, sessione o finale |
+| Differita |Selezionare tra assoluta, con obsolescenza limitata, sessione, prefisso coerente o finale |Finale |
+| Nessuno |Selezionare tra assoluta, con obsolescenza limitata, sessione, prefisso coerente o finale |Non applicabile |
 
 Come per le richieste di lettura, è possibile abbassare il livello di coerenza per una particolare richiesta di query specifica in ogni API.
 


### PR DESCRIPTION
"Decadimento ristretto" sostituito con "Obsolescenza Limitata" + correzione testi