### PR TITLE
reverted library name to original

### DIFF
--- a/articles/sql-database/sql-database-connectivity-issues.md
+++ b/articles/sql-database/sql-database-connectivity-issues.md
@@ -431,7 +431,7 @@ public bool IsTransient(Exception ex)
 * Per ulteriori informazioni sulla risoluzione di altri problemi di connessione di Database SQL comuni, vedere [risolvere i problemi di connessione al Database SQL di Azure](sql-database-troubleshoot-common-connection-issues.md).
 * [Raccolte di connessioni per database SQL e Server SQL](sql-database-libraries.md)
 * [SQL Server pool di connessioni (ADO.NET)](https://docs.microsoft.com/dotnet/framework/data/adonet/sql-server-connection-pooling)
-* [*Nuovo tentativo* è generica della libreria, scritta in Python, nuovo tentativo in corso una licenza di Apache 2.0](https://pypi.python.org/pypi/retrying) per semplificare l'attività di comportamento del nuovo tentativo di aggiunta a qualsiasi tipo.
+* [*Retrying* è una libreria generica, scritta in Python, con licenza Apache 2.0](https://pypi.python.org/pypi/retrying) per semplificare l'aggiunta di un comportamento di tipo "ritenta" a quasi qualsiasi azione.
 
 
 <!-- Link references. -->


### PR DESCRIPTION
one instance of the word "Retrying" was translated but it refers to the name of a library so it should stay in English. Also tried to reword that sentence to make it simpler and more understandable. feel free to improve my suggestion