### PR TITLE
Fix typo

### DIFF
--- a/articles/storage/data-lake-storage/quickstart-create-databricks-account.md
+++ b/articles/storage/data-lake-storage/quickstart-create-databricks-account.md
@@ -187,7 +187,7 @@ Dopo avere completato l'articolo, è possibile terminare il cluster. Nell'area d
 
 ![Arrestare un cluster Databricks](./media/quickstart-create-databricks-workspace-portal/terminate-databricks-cluster.png "Arrestare un cluster Databricks")
 
-Se non viene terminato manualmente, il cluster si arresta automaticamente se è stata selezionata la casella di controllo **Terminate after \_\_ minutes of inactivity** (Termina dopo __ minuti di attività) durante la creazione del cluster. Se si imposta questa opzione, il cluster si arresta dopo essere rimasto inattivo per il periodo di tempo specificato.
+Se non viene terminato manualmente, il cluster si arresta automaticamente se è stata selezionata la casella di controllo **Terminate after \_\_ minutes of inactivity** (Termina dopo \_\_ minuti di attività) durante la creazione del cluster. Se si imposta questa opzione, il cluster si arresta dopo essere rimasto inattivo per il periodo di tempo specificato.
 
 ## <a name="next-steps"></a>Passaggi successivi
 


### PR DESCRIPTION
Errore di battitura: `__` -> `\_\_`.
In Markdown `__` viene utilizzato per evidenziare. Per mostrare semplicemente `__`, dobbiamo uscire `\_\_`.